### PR TITLE
Allow base64 private key decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
     Note: You can also use pipeline templating to hide this private key in source control. (For more information: https://concourse.ci/fly-set-pipeline.html)
 
 * `private_key_base64`: *Optional.* Decode the private key from base64 encoding.
-    This is handy for credential stores that do not support multi-line strings,
-    Particularly Vault & SSM Parameter Store when using encryption
+    This is handy for credential stores that do not support multi-line strings, particularly Vault & AWS SSM Parameter Store when using encryption.
 
 * `username`: *Optional.* Username for HTTP(S) auth when pulling/pushing.
   This is needed when only HTTP/HTTPS protocol for git is available (which does not support private key auth)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
     ```
     Note: You can also use pipeline templating to hide this private key in source control. (For more information: https://concourse.ci/fly-set-pipeline.html)
 
+* `private_key_base64`: *Optional.* Decide the private key from base64 encoding.
+    This is handy for credential stores that do not support multi-line strings
+    Particularly Vault & SSM Parameter Store when using encryption
+
 * `username`: *Optional.* Username for HTTP(S) auth when pulling/pushing.
   This is needed when only HTTP/HTTPS protocol for git is available (which does not support private key auth)
   and auth is required.

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Tracks the commits in a [git](http://git-scm.com/) repository.
     ```
     Note: You can also use pipeline templating to hide this private key in source control. (For more information: https://concourse.ci/fly-set-pipeline.html)
 
-* `private_key_base64`: *Optional.* Decide the private key from base64 encoding.
-    This is handy for credential stores that do not support multi-line strings
+* `private_key_base64`: *Optional.* Decode the private key from base64 encoding.
+    This is handy for credential stores that do not support multi-line strings,
     Particularly Vault & SSM Parameter Store when using encryption
 
 * `username`: *Optional.* Username for HTTP(S) auth when pulling/pushing.

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -3,8 +3,13 @@ export GIT_CRYPT_KEY_PATH=~/git-crypt.key
 
 load_pubkey() {
   local private_key_path=$TMPDIR/git-resource-private-key
+  private_key_base64=$(jq -r '.source.private_key_base64 // false' < $1)
 
-  (jq -r '.source.private_key // empty' < $1) > $private_key_path
+  if [ "$private_key_base64" != "true" ]; then
+    (jq -r '.source.private_key // empty' < $1) > $private_key_path
+  else
+    (jq -r '.source.private_key // empty' < $1) | base64 -d > $private_key_path
+  fi
 
   if [ -s $private_key_path ]; then
     chmod 0600 $private_key_path


### PR DESCRIPTION
SSM Parameter Store does not support multi-line encrypted strings.

- Add `private_key_base64` parameter to allow reading in a key that is in base64 format.